### PR TITLE
logout session bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FastAPI를 사용하여 카카오 소셜 로그인, 로그아웃 기능을 구�
 프로젝트에 필요한 패키지를 설치합니다
 
 ```bash
-pip install fastapi uvicorn httpx python-dotenv jinja2
+pip install fastapi uvicorn httpx python-dotenv jinja2 itsdangerous python-multipart
 ```
 ## 환경 설정
 

--- a/app.py
+++ b/app.py
@@ -72,8 +72,10 @@ async def logout(request: Request):
         response = RedirectResponse(url="/")
         response.delete_cookie("access_token")  # 쿠키에서 access_token 삭제
         logger.debug("Access token removed from cookies")
-
-        return response
+        #################### 문제 ##############################
+        logout_url = f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}&state=state"
+        #return response
+        return RedirectResponse(url=logout_url)  # 카카오 로그아웃 페이지로 리디렉션
     
     logger.debug("No access_token in session")
     return RedirectResponse(url="/?error=Not logged in", status_code=302)

--- a/app.py
+++ b/app.py
@@ -101,4 +101,4 @@ async def refresh_token(refresh_token: str = Form(...)):
 
 # 애플리케이션을 실행하기 위한 코드
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=3000)

--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ async def logout(request: Request):
         # 카카오 로그아웃 처리
         client_id = kakao_api.client_id
         logout_redirect_uri = kakao_api.logout_redirect_uri
-        await kakao_api.logout(client_id, logout_redirect_uri)
+        logout_url = await kakao_api.logout(client_id, logout_redirect_uri)
 
         # 애플리케이션 내 세션에서 토큰 삭제
         request.session.pop('access_token', None)
@@ -72,9 +72,6 @@ async def logout(request: Request):
         response = RedirectResponse(url="/")
         response.delete_cookie("access_token")  # 쿠키에서 access_token 삭제
         logger.debug("Access token removed from cookies")
-        #################### 문제 ##############################
-        logout_url = f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}&state=state"
-        #return response
         return RedirectResponse(url=logout_url)  # 카카오 로그아웃 페이지로 리디렉션
     
     logger.debug("No access_token in session")

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -19,8 +19,8 @@ class KakaoAPI:
 
     def getcode_auth_url(self, scope):
         # 카카오 로그인을 위한 인증 URL 생성
-        return f'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={self.client_id}&redirect_uri={self.redirect_uri}&scope={scope}'
-
+        #return f'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={self.client_id}&redirect_uri={self.redirect_uri}&scope={scope}'
+        return f'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={self.client_id}&redirect_uri={self.redirect_uri}&scope={scope}&prompt=login'
     async def get_token(self, code):
         # 카카오로부터 인증 코드를 사용해 액세스 토큰 요청
         token_request_url = 'https://kauth.kakao.com/oauth/token'

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -2,6 +2,7 @@ import httpx
 import os
 from dotenv import load_dotenv
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import JSONResponse
 import logging
 
 # 로깅 설정

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -48,7 +48,8 @@ class KakaoAPI:
     
     async def logout(self, client_id, logout_redirect_uri):
         # 카카오 로그아웃 URL을 호출하여 로그아웃 처리
-        logout_url = f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}"
+        logout_url = f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}&state=state"
+        
         async with httpx.AsyncClient() as client:
             await client.get(logout_url)
     

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -2,6 +2,11 @@ import httpx
 import os
 from dotenv import load_dotenv
 from fastapi.templating import Jinja2Templates
+import logging
+
+# 로깅 설정
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 # Jinja2 템플릿 설정
 templates = Jinja2Templates(directory="templates")
@@ -45,14 +50,20 @@ class KakaoAPI:
         async with httpx.AsyncClient() as client:
             response = await client.get(userinfo_endpoint, headers=headers)
         return response.json() if response.status_code == 200 else None
-    
+
     async def logout(self, client_id, logout_redirect_uri):
+        if not logout_redirect_uri:
+            logger.error("Logout redirect URI is missing.")
+        else:
+            logger.debug(f"Logout redirect URI: {logout_redirect_uri}")
+        
         # 카카오 로그아웃 URL을 호출하여 로그아웃 처리
         logout_url = f"https://kauth.kakao.com/oauth/logout?client_id={client_id}&logout_redirect_uri={logout_redirect_uri}&state=state"
         
         async with httpx.AsyncClient() as client:
-            await client.get(logout_url)
-    
+            response = await client.get(logout_url)
+            return logout_url
+
     async def refreshAccessToken(self, clientId, refresh_token):
         # 리프레시 토큰을 사용하여 액세스 토큰 갱신 요청
         url = "https://kauth.kakao.com/oauth/token"

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -27,6 +27,7 @@ class KakaoAPI:
         # 카카오 로그인을 위한 인증 URL 생성
         #return f'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={self.client_id}&redirect_uri={self.redirect_uri}&scope={scope}'
         return f'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={self.client_id}&redirect_uri={self.redirect_uri}&scope={scope}&prompt=login'
+    
     async def get_token(self, code):
         # 카카오로부터 인증 코드를 사용해 액세스 토큰 요청
         token_request_url = 'https://kauth.kakao.com/oauth/token'


### PR DESCRIPTION
## 에러
- 카카오 로그아웃 시 세션창이 뜨지 않는 버그가 있었습니다.
- 로그아웃은 정상적으로 되었으나 리디렉션이 잘 이루어지지 않는 버그도 있었습니다.
- 아마 두 개 버그가 이어지는 것으로 추정

## 기존코드 app.py
```bash
# 로그아웃 처리 엔드포인트
@app.get("/logout")
async def logout(request: Request):
    access_token = request.session.get('access_token')
    logger.debug(f"Initial access_token in session: {access_token}")
    if access_token:
        # 카카오 로그아웃 처리
        client_id = kakao_api.client_id
        logout_redirect_uri = kakao_api.logout_redirect_uri
        await kakao_api.logout(client_id, logout_redirect_uri)

        # 애플리케이션 내 세션에서 토큰 삭제
        request.session.pop('access_token', None)
        logger.debug("Access token removed from session")

        # 쿠키에서 access_token 삭제
        response = RedirectResponse(url="/")
        response.delete_cookie("access_token")  # 쿠키에서 access_token 삭제
        logger.debug("Access token removed from cookies")
        return response
    
    logger.debug("No access_token in session")
    return RedirectResponse(url="/?error=Not logged in", status_code=302)
```