### PR TITLE
callback 엔드포인트 동작 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FastAPI를 사용하여 카카오 소셜 로그인, 로그아웃 기능을 구�
 프로젝트에 필요한 패키지를 설치합니다
 
 ```bash
-pip install fastapi uvicorn httpx python-dotenv jinja2
+pip install fastapi uvicorn httpx python-dotenv jinja2 itsdangerous python-multipart
 ```
 ## 환경 설정
 

--- a/app.py
+++ b/app.py
@@ -2,9 +2,11 @@ from fastapi import FastAPI, Request, HTTPException, Form
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import JSONResponse
 from kakao_manager import KakaoAPI
 import uvicorn
 import logging
+import httpx
 
 # 로깅 설정
 logging.basicConfig(level=logging.DEBUG)
@@ -37,10 +39,29 @@ async def kakao_callback(request: Request, code: str):
         access_token = token_info['access_token']  # access_token을 변수에 저장
         request.session['access_token'] = access_token
         logger.debug(f"Access token saved in session: {access_token}")  # access_token 로그 출력
-        return RedirectResponse(url="/user_info", status_code=302)
+         # 카카오에서 유저 정보 가져오기
+        user_info_response = await get_user_info_from_kakao(access_token)
+
+        if user_info_response:
+            return JSONResponse(content=user_info_response)
+        else:
+            return JSONResponse(content={"error": "Failed to get user info"}, status_code=400)
     else:
-        logger.error("Failed to authenticate with Kakao") 
-        return RedirectResponse(url="/?error=Failed to authenticate", status_code=302)
+        logger.error("Failed to authenticate with Kakao")
+        return JSONResponse(content={"error": "Failed to authenticate"}, status_code=400)
+
+async def get_user_info_from_kakao(access_token: str):
+    url = "https://kapi.kakao.com/v2/user/me"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, headers=headers)
+
+    if response.status_code == 200:
+        return response.json()  # 유저 정보 반환
+    else:
+        logger.error(f"Failed to fetch user info from Kakao: {response.text}")
+        return None
 
 # 홈페이지 및 로그인/로그아웃 버튼을 표시
 @app.get("/", response_class=HTMLResponse)

--- a/app.py
+++ b/app.py
@@ -122,4 +122,4 @@ async def refresh_token(refresh_token: str = Form(...)):
 
 # 애플리케이션을 실행하기 위한 코드
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=3000)

--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def get_kakao_code(request: Request):
     kakao_auth_url = kakao_api.getcode_auth_url(scope)
     return RedirectResponse(kakao_auth_url)
 
-# 카카오 로그인 후 카카오에서 리디렉션될 엔드포인트
+# 카카오 로그인 후 카카오에서 반환된 access_token과 사용자 정보를 JSON 데이터로 반환
 @app.get("/callback")
 async def kakao_callback(request: Request, code: str):
     token_info = await kakao_api.get_token(code)

--- a/kakao_manager.py
+++ b/kakao_manager.py
@@ -2,6 +2,7 @@ import httpx
 import os
 from dotenv import load_dotenv
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import JSONResponse
 import logging
 
 # 로깅 설정


### PR DESCRIPTION
## 프론트 요구사항

카카오 로그인 콜백페이지 변경
-  리다이렉트 빼고 데이터만 리턴


## 기존코드 

app.py
```
@app.get("/callback")
async def kakao_callback(request: Request, code: str):
    token_info = await kakao_api.get_token(code)
    logger.debug(f"Token info from Kakao: {token_info}")
    if "access_token" in token_info:
        access_token = token_info['access_token']  # access_token을 변수에 저장
        request.session['access_token'] = access_token
        logger.debug(f"Access token saved in session: {access_token}")  # access_token 로그 출력
        return RedirectResponse(url="/user_info", status_code=302)
    else:
        logger.error("Failed to authenticate with Kakao") 
        return RedirectResponse(url="/?error=Failed to authenticate", status_code=302)
```

user_info.html
```
<body>
    <h2>User Information</h2>
    <p>ID: {{ user_info.id }}</p>
    <p>Email: {{ user_info.kakao_account.email }}</p>
    <!-- 기타 필요한 사용자 정보 필드 추가 -->
    <a href="/">Back to Home</a>
</body>
```

카카오 인증 후 RedirectResponse를 통해 user_info 페이지로 리디렉션.