### PR TITLE
로그아웃 엔드포인트의 JWT 처리 방식 개선

### DIFF
--- a/.pdm-python
+++ b/.pdm-python
@@ -1,1 +1,0 @@
-/home/oddsummer/finalTU/final_login/.venv/bin/python

--- a/src/final_login/db_model.py
+++ b/src/final_login/db_model.py
@@ -15,15 +15,18 @@ db = client.get_database("signup")
 user_collection = db.get_collection("users")
 
 # Pydantic 모델
+# 유저 데이터터
 class User(BaseModel):
     id: str
     password: str
 
+# JWT 토큰 반환
 class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
     token_type: str
 
+# 회원가입 입력 데이터
 class UserSignUp(BaseModel):
     username: str
     id: str
@@ -36,6 +39,10 @@ class UserSignUp(BaseModel):
     create_at: Optional[str] = None
     auth_id: Optional[str] = None
 
-# Pydantic 모델 (아이디 중복 체크 요청 데이터)
+# 아이디 중복 체크
 class IDCheck(BaseModel):
     id: str
+
+# JWT 토큰 
+class TokenBody(BaseModel):
+    token: str

--- a/src/final_login/routes/auth.py
+++ b/src/final_login/routes/auth.py
@@ -1,12 +1,13 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from datetime import timedelta
 from src.final_login.db_model import User, TokenResponse
 from src.final_login.token import SECRET_KEY, ALGORITHM
 from fastapi import Depends, Request
-from src.final_login.validate import validate_user
+from src.final_login.validate import validate_user, verify_token
 from src.final_login.token import create_access_token, create_refresh_token
 from src.final_login.log_handler import log_event
-from src.final_login.db_model import IDCheck
+from src.final_login.db_model import TokenBody
+from jose import JWTError, ExpiredSignatureError
 
 auth_router = APIRouter()
 
@@ -53,24 +54,48 @@ async def login(request: Request, user: User = Depends(validate_user)):
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
 """
+
 @auth_router.post("/logout")
-async def logout(request: Request, user_id: IDCheck):
+async def logout(body: TokenBody, request: Request):
+    # 요청 본문에서 JWT 토큰 확인
+    token = body.token  # Pydantic 모델에서 token 필드 추출
+    if not token:
+        print("Token is missing in the request body.")
+        raise HTTPException(status_code=400, detail="Token is missing in the request body.")
 
-    # 로그를 위한 device, user_id 추출
+    # 토큰 검증 및 디코딩
+    try:
+        decoded_token = verify_token(
+            token=token,
+            SECRET_KEY=SECRET_KEY,
+            ALGORITHM=ALGORITHM,
+            refresh_token=None,
+            expires_delta=None
+        )
+    except ExpiredSignatureError:
+        # 토큰이 만료되었을 경우, 로그아웃을 허용
+        print("Token is expired. Proceeding with logout.")
+        decoded_token = None  # 만료된 토큰이라도 로그아웃 진행
+    except JWTError as e:
+        print(f"Token verification failed: {str(e)}")
+        raise HTTPException(status_code=401, detail="Invalid token.")
 
+    # 디코드된 데이터에서 사용자 ID 추출
+    user_id = decoded_token.get("id", "anonymous")
     device = request.headers.get("User-Agent", "Unknown")
     ip_address = request.client.host
 
+    #print(f"Decoded user_id: {user_id}")  # 디버깅 출력
+
+    # 로그 기록
     try:
-        # 로그 이벤트 기록
         log_event(
-            user_id=user_id.id,  
-            device=device,     
-            action="Logout",   
-            ip_address= ip_address
+            user_id=user_id,
+            device=device,
+            action="Logout",
+            ip_address=ip_address
         )
     except Exception as e:
         print(f"Error logging event: {e}")
 
     return {"message": "Logged out successfully"}
-


### PR DESCRIPTION
## 기존 방식
```
@auth_router.post("/logout")
async def logout(request: Request, user_id: IDCheck):
```
IDCheck에서 user_id를 받아오는 방식. 
프론트엔드에서 ID가 포함되어 요청되지 않으므로 값을 찾을 수 없어 422 Unprocessable Entity 에러가 발생

## 변경 사항
### 1. 백엔드 
#### 1. jwt 토큰 검증 코드 추가 (verify_token)
- 클라이언트에서 전달받은 JWT 토큰의 유효성을 확인하고, 만료된 경우 리프레시 토큰으로 새로운 액세스 토큰을 재발급.
```
def verify_token(token: str, SECRET_KEY: str, ALGORITHM: str, refresh_token: str, expires_delta: timedelta) -> Dict[str, str]:
    """ JWT 토큰 검증 및 만료된 경우 refresh token으로 access token 재발급 """
    try:
        # Access token 검증
        decoded_token = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])

        # 토큰이 만료되었는지 확인 (만료되었다면 refresh token 사용)
        if datetime.utcfromtimestamp(decoded_token['exp']) < datetime.utcnow():
            # 만약 만료되었다면 refresh token을 사용하여 새로운 access token 발급
            new_access_token = refresh_access_token(refresh_token, SECRET_KEY, ALGORITHM, expires_delta)
            return {"access_token": new_access_token}
        
        return decoded_token

    except jwt.ExpiredSignatureError:
        raise HTTPException(status_code=401, detail="Token has expired")
    except jwt.JWTError:
        raise HTTPException(status_code=401, detail="Invalid token")
```

#### 2. 로그아웃 API 변경
- Pydantic 모델(TokenBody)을 통해 본문에서 JWT 토큰 추출 및 검증.
- verify_token 함수로 토큰 검증 및 디코딩 후, user_id를 추출하여 로그아웃 처리.
- 만료된 토큰도 로그아웃 요청을 허용.

```
@auth_router.post("/logout")
async def logout(body: TokenBody, request: Request):
    # 요청 본문에서 JWT 토큰 확인
    token = body.token  # Pydantic 모델에서 token 필드 추출
    if not token:
        print("Token is missing in the request body.")
        raise HTTPException(status_code=400, detail="Token is missing in the request body.")

    # 토큰 검증 및 디코딩
    try:
        decoded_token = verify_token(
            token=token,
            SECRET_KEY=SECRET_KEY,
            ALGORITHM=ALGORITHM,
            refresh_token=None,
            expires_delta=None
        )
    except ExpiredSignatureError:
        # 토큰이 만료되었을 경우, 로그아웃을 허용
        print("Token is expired. Proceeding with logout.")
        decoded_token = None  # 만료된 토큰이라도 로그아웃 진행
    except JWTError as e:
        print(f"Token verification failed: {str(e)}")
        raise HTTPException(status_code=401, detail="Invalid token.")

    # 디코드된 데이터에서 사용자 ID 추출
    user_id = decoded_token.get("id", "anonymous")
    device = request.headers.get("User-Agent", "Unknown")
    ip_address = request.client.host
```


### 2. 프론트엔드  

#### 1.  클라이언트 요청에서 Content-Type 헤더를 명시적으로 포함  
설명 참고: #13  

```
{
	headers: { "Content-Type": "application/json" }
}
```

#### 2. 요청 본문에 JWT 토큰을 포함해 전달
```
{
   body:JSON.stringify({"token":loadSession("loginToken")})
}
```